### PR TITLE
Only use NPM_TOKEN if it's available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ jobs:
     - stage: release
       node_js: lts/*
       script:
-        - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+        - if [[ -n "${NPM_TOKEN}" ]]; then echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc; fi
         - yarn run semantic-release


### PR DESCRIPTION
The NPM_TOKEN environment variable is not available in builds from
forked branches. So only write an .npmrc if the variable is available.
Otherwise semantic-release will fail.